### PR TITLE
handle buffer alloc errors and quoted tilde

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ tmp/
 *.out
 *.app
 
+.cache

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -9,13 +9,6 @@
 
 std::atomic<bool> stop_display{false}; 
 
-const int PROMPT_CONTEXT_VERSION = 1;
-
-struct llmodel_prompt_context_with_version {
-  int version;
-  llmodel_prompt_context prompt_context;
-};
-
 void display_frames() {
     const char* frames[] = {".", ":", "'", ":"};
     int frame_index = 0;
@@ -174,11 +167,6 @@ bool save_ctx_to_binary(llmodel_prompt_context& prompt_context, chatParams& para
 	  params.save_dir = params.path+"saves";
 	}
 	
-  // Add version field to the struct 
-   llmodel_prompt_context_with_version prompt_context_with_version;
-    prompt_context_with_version.version = PROMPT_CONTEXT_VERSION;
-    prompt_context_with_version.prompt_context = prompt_context;
-
     // Open the binary file for writing
     FILE* file = fopen((params.save_dir+"/"+filename+".ctx").c_str(), "wb");
     if (!file) {
@@ -187,7 +175,8 @@ bool save_ctx_to_binary(llmodel_prompt_context& prompt_context, chatParams& para
     }
 
     // Write the struct to the file using fwrite
-    fwrite(&prompt_context_with_version, sizeof(llmodel_prompt_context_with_version), 1, file);
+    size_t size = sizeof(llmodel_prompt_context);
+    fwrite(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
 
     // Close the file
     fclose(file);
@@ -208,16 +197,9 @@ llmodel_prompt_context load_ctx_from_binary(chatParams& params, std::string &fil
     }
 
     // Read the struct from the file using fread
-    llmodel_prompt_context_with_version prompt_context_with_version;
-    fread(&prompt_context_with_version, sizeof(prompt_context_with_version), 1, file);
-
-    if (prompt_context_with_version.version != PROMPT_CONTEXT_VERSION) {
-        std::cerr << "Error: Invalid version of the context file" << std::endl;
-        exit(EXIT_FAILURE);
-    }
-
-    // Get the prompt context from the struct
-    llmodel_prompt_context prompt_context = prompt_context_with_version.prompt_context;
+    llmodel_prompt_context prompt_context;
+    size_t size = sizeof(llmodel_prompt_context);
+    fread(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
 
     // Close the file
     fclose(file);

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -9,6 +9,13 @@
 
 std::atomic<bool> stop_display{false}; 
 
+const int PROMPT_CONTEXT_VERSION = 1;
+
+struct llmodel_prompt_context_with_version {
+  int version;
+  llmodel_prompt_context prompt_context;
+};
+
 void display_frames() {
     const char* frames[] = {".", ":", "'", ":"};
     int frame_index = 0;
@@ -161,6 +168,11 @@ bool save_ctx_to_binary(llmodel_prompt_context& prompt_context, chatParams& para
 	  params.save_dir = params.path+"saves";
 	}
 	
+  // Add version field to the struct 
+   llmodel_prompt_context_with_version prompt_context_with_version;
+    prompt_context_with_version.version = PROMPT_CONTEXT_VERSION;
+    prompt_context_with_version.prompt_context = prompt_context;
+
     // Open the binary file for writing
     FILE* file = fopen((params.save_dir+"/"+filename+".ctx").c_str(), "wb");
     if (!file) {
@@ -169,8 +181,7 @@ bool save_ctx_to_binary(llmodel_prompt_context& prompt_context, chatParams& para
     }
 
     // Write the struct to the file using fwrite
-    size_t size = sizeof(llmodel_prompt_context);
-    fwrite(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
+    fwrite(&prompt_context_with_version, sizeof(llmodel_prompt_context_with_version), 1, file);
 
     // Close the file
     fclose(file);
@@ -191,9 +202,16 @@ llmodel_prompt_context load_ctx_from_binary(chatParams& params, std::string &fil
     }
 
     // Read the struct from the file using fread
-    llmodel_prompt_context prompt_context;
-    size_t size = sizeof(llmodel_prompt_context);
-    fread(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
+    llmodel_prompt_context_with_version prompt_context_with_version;
+    fread(&prompt_context_with_version, sizeof(prompt_context_with_version), 1, file);
+
+    if (prompt_context_with_version.version != PROMPT_CONTEXT_VERSION) {
+        std::cerr << "Error: Invalid version of the context file" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
+    // Get the prompt context from the struct
+    llmodel_prompt_context prompt_context = prompt_context_with_version.prompt_context;
 
     // Close the file
     fclose(file);

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -144,6 +144,12 @@ bool load_state_from_binary(llmodel_model& model, chatParams& params, std::strin
 
   // allocate a buffer to hold the file data
   uint8_t* buffer = new uint8_t[file_size];
+  try {
+    buffer = new uint8_t[file_size];
+  } catch (std::bad_alloc& ba) {
+    std::cerr << "Failed to allocate buffer: " << ba.what() << std::endl;
+    return false;
+  }
 
   // read the file data into the buffer
   infile.read(reinterpret_cast<char*>(buffer), file_size);

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -166,17 +166,19 @@ bool save_ctx_to_binary(llmodel_prompt_context& prompt_context, chatParams& para
     }
 	  params.save_dir = params.path+"saves";
 	}
+
+  std::filesystem::path filePath = std::filesystem::path(params.save_dir) / (filename + ".ctx");
+  std::string fullPath = filePath.string();
 	
     // Open the binary file for writing
-    FILE* file = fopen((params.save_dir+"/"+filename+".ctx").c_str(), "wb");
+  FILE* file = fopen(fullPath.c_str(), "wb");
     if (!file) {
-        std::cerr << "Error opening file: " << params.save_dir+"/"+filename+".ctx" << std::endl;
+        std::cerr << "Error opening file: " << fullPath << std::endl;
         return false;
     }
 
     // Write the struct to the file using fwrite
-    size_t size = sizeof(llmodel_prompt_context);
-    fwrite(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
+    fwrite(&prompt_context, sizeof(prompt_context), 1, file);
 
     // Close the file
     fclose(file);
@@ -188,18 +190,20 @@ llmodel_prompt_context load_ctx_from_binary(chatParams& params, std::string &fil
  	if (params.save_dir == "") {
 		params.save_dir = params.path+"saves";
  	}
-	
+	  // Construct the file path with home directory expansion
+    std::filesystem::path filePath = std::filesystem::path(params.save_dir) / (filename + ".ctx");
+    std::string fullPath = filePath.string();
+
     // Open the binary file for reading
-    FILE* file = fopen((params.save_dir+"/"+filename+".ctx").c_str(), "rb");
-    if (!file) {
-        std::cerr << "Error opening file: " << params.save_dir+"/"+filename+".ctx" << std::endl;
+    FILE* file = fopen(fullPath.c_str(), "rb");
+        if (!file) {
+        std::cerr << "Error opening file: " << fullPath << std::endl;
         exit(EXIT_FAILURE);
     }
 
     // Read the struct from the file using fread
     llmodel_prompt_context prompt_context;
-    size_t size = sizeof(llmodel_prompt_context);
-    fread(&prompt_context, sizeof(llmodel_prompt_context), 1, file);
+    fread(&prompt_context, sizeof(prompt_context), 1, file);
 
     // Close the file
     fclose(file);


### PR DESCRIPTION
I've run into an issue where using the quoted tilde, which doesn't expand in quotation marks instead of `$HOME` causes boundary errors and a segfault with no meaningful core dump. This is an attempt to fix this issue. Alternatively some early return can be used if the argument contains a tilde, or the program should handle rewriting the tilde into `$HOME`